### PR TITLE
Add scratch page for exploring JavaScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Projects can be found in the `projects` folder.
 
 Exercise repos are "forked" into directiories under `exercises`.
 
+A readymade boilerplate page with a linked script for exploring JavaScript is available under `scratch`.
+
 ## TODO
 
 1. Once setup with `npm`, run the following checks locally and with CI; currently just running via VSCode extensions:

--- a/scratch/README.md
+++ b/scratch/README.md
@@ -1,0 +1,3 @@
+# Scratch
+
+HTML page with the minimal boilerplate required to work with JavaScript in the console.

--- a/scratch/index.html
+++ b/scratch/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Scratch</title>
+    <script src="script.js"></script>
+</head>
+<body>
+
+</body>
+</html>


### PR DESCRIPTION
A readymade boilerplate page with a linked script for exploring JavaScript is now available under `scratch`.