### PR TITLE
Scratch: Defer script import until DOM has loaded

### DIFF
--- a/scratch/index.html
+++ b/scratch/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Scratch</title>
-    <script src="script.js"></script>
+    <script src="script.js" defer></script>
 </head>
 <body>
 


### PR DESCRIPTION
In `scratch/index.html`, add the `defer` attribute when loading `script.js` so that all DOM elements have finished loading; this allows us to interact with all elements in the DOM via the JavaScript we define in this file